### PR TITLE
Fix IPython spelling.

### DIFF
--- a/fosdem.ipynb
+++ b/fosdem.ipynb
@@ -78,7 +78,7 @@
    },
    "source": [
     "### Jupyter\n",
-    "* iPython: 2001-present\n",
+    "* IPython: 2001-present\n",
     "* Jupyter: 2014-present\n",
     "* Goals\n",
     " * Improve Read-Eval-Print-Loop (REPL) interface\n",


### PR DESCRIPTION
IPython is spelled with an upper case I, I know it's hard because of
Apple products.

-- 
At the same time can you fix the spelling in https://github.com/bduggan/p6-jupyter-kernel description that can't be fixed via PRs ?

<img width="374" alt="screen shot 2018-02-06 at 13 47 23" src="https://user-images.githubusercontent.com/335567/35885932-4e725a38-0b44-11e8-85dc-05cb8a9c4620.png">

Thanks !